### PR TITLE
게시글(Post) - 병합 후 변경 사항 

### DIFF
--- a/src/main/java/com/sounganization/botanify/domain/community/controller/PostController.java
+++ b/src/main/java/com/sounganization/botanify/domain/community/controller/PostController.java
@@ -33,7 +33,7 @@ public class PostController {
     //게시글 조회 - 다건조회
     @GetMapping
     public ResponseEntity<Page<PostListResDto>> readPosts(
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size) {
         Page<PostListResDto> postListResDto = postService.readPosts(page, size);
         return ResponseEntity.ok(postListResDto);

--- a/src/main/java/com/sounganization/botanify/domain/community/dto/res/CommentTempDto.java
+++ b/src/main/java/com/sounganization/botanify/domain/community/dto/res/CommentTempDto.java
@@ -1,5 +1,6 @@
 package com.sounganization.botanify.domain.community.dto.res;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sounganization.botanify.domain.community.entity.Comment;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,6 +14,7 @@ import java.util.stream.Collectors;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class CommentTempDto {
     private Long commentId;
     private Long userId;
@@ -21,7 +23,7 @@ public class CommentTempDto {
     private List<CommentTempDto> childComments;
 
 
-    public static CommentTempDto from(Comment comment,String username) {
+    public static CommentTempDto from(Comment comment, String username) {
         return CommentTempDto.builder()
                 .commentId(comment.getId())
                 .userId(comment.getUserId())

--- a/src/main/java/com/sounganization/botanify/domain/community/repository/CommentRepository.java
+++ b/src/main/java/com/sounganization/botanify/domain/community/repository/CommentRepository.java
@@ -18,6 +18,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         LEFT JOIN FETCH c.parentComment
         LEFT JOIN FETCH c.childComments
         WHERE c.post.id = :postId AND c.parentComment.id IS NULL
+        AND c.deletedYn = false
         ORDER BY c.parentComment.id NULLS FIRST, c.id
     """)
         List<Comment> findCommentsByPostId(@Param("postId") Long postId);

--- a/src/main/java/com/sounganization/botanify/domain/community/service/PostService.java
+++ b/src/main/java/com/sounganization/botanify/domain/community/service/PostService.java
@@ -52,7 +52,7 @@ public class PostService {
     // 게시글 조회 - 다건 조회
     public Page<PostListResDto> readPosts(int page, int size) {
         //pageable
-        Pageable pageable = PageRequest.of(page, size, Sort.by("updatedAt").descending());
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("updatedAt").descending());
         Page<Post> posts = postRepository.findAll(pageable);
         return posts.map(post -> postMapper.entityToResDto(post));
     }


### PR DESCRIPTION
### 이슈번호 #31

#### 작업 내용
- 페이징 page 0 ->1로 변경 
-  삭제된 댓글 (softDelete) deleted_yn false만 조회하도록 조건 추가 
-  대댓글 없을 경우 응답 데이터에서 제외

#### 참고사항
- 게시글 단건 조회 (게시글+댓글) queryDsl로 구현 예정 