### PR TITLE
인기글 캐싱 - 주기적 점수 update의 scheduling

### DIFF
--- a/src/main/java/com/sounganization/botanify/BotanifyApplication.java
+++ b/src/main/java/com/sounganization/botanify/BotanifyApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class BotanifyApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/sounganization/botanify/domain/community/repository/CommentCustomRepository.java
+++ b/src/main/java/com/sounganization/botanify/domain/community/repository/CommentCustomRepository.java
@@ -4,7 +4,9 @@ import com.sounganization.botanify.domain.community.entity.Comment;
 
 
 import java.util.List;
+import java.util.Map;
 
 public interface CommentCustomRepository {
     List<Comment> findCommentsByPostId(Long postId);
+    Map<Long, Long> countCommentsByPostIds(List<Long> postIds);
 }

--- a/src/main/java/com/sounganization/botanify/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/sounganization/botanify/domain/community/repository/PostRepository.java
@@ -5,7 +5,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByDeletedYnFalse(Pageable pageable);
     Page<Post> findAllByUserIdAndDeletedYnFalse(Long userId, Pageable pageable);
+
+    List<Post> findAllByDeletedYnFalse();
 }


### PR DESCRIPTION
## 기능
주기적 점수 update의 scheduling

## 목표
- 지속적으로 변화되는 인기글의 조회수와 댓글
- 정기적인 update를 통해 정확한 순위 보장
- Update를 일괄 처리하여 Redis의 부하 감소

## 개선
- `JOIN`을 사용한 `COUNT` query를 `QueryDSL`로 작성하여 모든 댓글을 가져오는 대신 불필요한 데이터 전송 감소
- N+1 문제 해결