### PR TITLE
댓글과 대댓글 code의 개선 및 최적화 

### DIFF
--- a/src/main/java/com/sounganization/botanify/common/exception/ExceptionStatus.java
+++ b/src/main/java/com/sounganization/botanify/common/exception/ExceptionStatus.java
@@ -56,6 +56,7 @@ public enum ExceptionStatus {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     COMMENT_NOT_OWNED(HttpStatus.FORBIDDEN, "댓글 작성자만 댓글을 수정하거나 삭제할 수 있습니다."),
     COMMENT_ALREADY_DELETED(HttpStatus.CONFLICT, "이미 삭제된 댓글입니다."),
+    MAX_COMMENT_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "댓글의 최대 깊이를 초과하였습니다. 직접 댓글을 작성해주세요."),
 
     // chat
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),

--- a/src/main/java/com/sounganization/botanify/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/sounganization/botanify/domain/chat/controller/ChatController.java
@@ -30,12 +30,13 @@ public class ChatController {
     private final ChatMessageMapper chatMessageMapper;
 
     @PostMapping("/rooms")
-    public ResponseEntity<ChatRoom> createChatRoom(
+    public ResponseEntity<ChatRoomResDto> createChatRoom(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam Long receiverId
     ) {
         ChatRoom chatRoom = chatRoomService.createChatRoom(userDetails.getId(), receiverId);
-        return ResponseEntity.status(HttpStatus.CREATED).body(chatRoom);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(chatRoomMapper.toResDto(chatRoom));
     }
 
     @GetMapping("/rooms")

--- a/src/main/java/com/sounganization/botanify/domain/community/entity/Comment.java
+++ b/src/main/java/com/sounganization/botanify/domain/community/entity/Comment.java
@@ -25,8 +25,6 @@ public class Comment extends Timestamped {
     @Column(nullable = false)
     private String content;
 
-    // todo - N+1 발생 시 Projection 사용해보기
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Comment parentComment;
@@ -41,6 +39,13 @@ public class Comment extends Timestamped {
 
     @Column(nullable = false)
     private Long userId;
+
+    @Column(nullable = false)
+    private Integer depth;
+
+    public static class CommentBuilder {
+        private Integer depth = 0;
+    }
 
     public void update(String content) {
         if(content == null || content.trim().isEmpty()) {

--- a/src/main/java/com/sounganization/botanify/domain/community/mapper/CommentMapper.java
+++ b/src/main/java/com/sounganization/botanify/domain/community/mapper/CommentMapper.java
@@ -17,6 +17,7 @@ public interface CommentMapper {
     @Mapping(target = "parentComment", source = "parentComment")
     @Mapping(target = "content", source = "requestDto.content")
     @Mapping(target = "childComments", ignore = true)
+    @Mapping(target = "depth", expression = "java(parentComment.getDepth() + 1)")
     Comment toEntity(CommentReqDto requestDto, Post post, Long userId, Comment parentComment);
 
     default CommonResDto toResDto(Comment comment) {

--- a/src/main/java/com/sounganization/botanify/domain/community/mapper/CommentMapper.java
+++ b/src/main/java/com/sounganization/botanify/domain/community/mapper/CommentMapper.java
@@ -17,7 +17,7 @@ public interface CommentMapper {
     @Mapping(target = "parentComment", source = "parentComment")
     @Mapping(target = "content", source = "requestDto.content")
     @Mapping(target = "childComments", ignore = true)
-    @Mapping(target = "depth", expression = "java(parentComment.getDepth() + 1)")
+    @Mapping(target = "depth", expression = "java(parentComment == null ? 0 : parentComment.getDepth() + 1)")
     Comment toEntity(CommentReqDto requestDto, Post post, Long userId, Comment parentComment);
 
     default CommonResDto toResDto(Comment comment) {

--- a/src/main/java/com/sounganization/botanify/domain/community/repository/CommentCustomRepository.java
+++ b/src/main/java/com/sounganization/botanify/domain/community/repository/CommentCustomRepository.java
@@ -5,8 +5,10 @@ import com.sounganization.botanify.domain.community.entity.Comment;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface CommentCustomRepository {
     List<Comment> findCommentsByPostId(Long postId);
     Map<Long, Long> countCommentsByPostIds(List<Long> postIds);
+    Optional<Comment> findCommentsById(Long commentId);
 }

--- a/src/main/java/com/sounganization/botanify/domain/community/service/CommentService.java
+++ b/src/main/java/com/sounganization/botanify/domain/community/service/CommentService.java
@@ -110,7 +110,7 @@ public class CommentService {
         userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ExceptionStatus.USER_NOT_FOUND));
 
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findCommentsById(commentId)
                 .orElseThrow(() -> new CustomException(ExceptionStatus.COMMENT_NOT_FOUND));
 
         if (comment.getDeletedYn()) {

--- a/src/main/java/com/sounganization/botanify/domain/community/service/CommentService.java
+++ b/src/main/java/com/sounganization/botanify/domain/community/service/CommentService.java
@@ -24,6 +24,8 @@ public class CommentService {
     private final CommentMapper commentMapper;
     private final PopularPostService popularPostService;
 
+    private static final int MAX_COMMENT_DEPTH = 1;
+
     @Transactional
     public CommonResDto createComment(Long postId, CommentReqDto requestDto, Long userId) {
 
@@ -58,6 +60,10 @@ public class CommentService {
 
         Comment parentComment = commentRepository.findById(parentCommentId)
                 .orElseThrow(() -> new CustomException(ExceptionStatus.COMMENT_NOT_FOUND));
+
+        if (parentComment.getDepth() >= MAX_COMMENT_DEPTH) {
+            throw new CustomException(ExceptionStatus.MAX_COMMENT_DEPTH_EXCEEDED);
+        }
 
         if (parentComment.getDeletedYn()) {
             throw new CustomException(ExceptionStatus.COMMENT_ALREADY_DELETED);


### PR DESCRIPTION
## 개선 및 최적화 내용
- 대댓글의 무한한 중첩 방지를 위한 깊이 제한 logic 추가:
   - 댓글 깊이를 one level로 제한(댓글은 답글을 가질 수 있지만, 답글은 다시 답글을 가질 수 없습니다)
   - 데이터 일관성 유지
   - 깊은 중첩으로 인한 성능 문제 방지
   - 사용자에게 명확한 오류 메시지를 제공
   - 댓글 생성 시 `NullPointer` 문제 해결
- 대댓글의 조회 시 N+1 문제를 해결하는 logic 추가:
   - N+1 query를 피하기 위해 `Fetch Join` 사용
   - 자식 댓글을 하나의 query로 load함
   - 적절한 순서 유지
   - 삭제되지 않은 댓글만 포함
   - 최상위 댓글과 답글을 구분

## 기타 bug 수정
`ChatController`에서 채팅방 생성 return type 수정